### PR TITLE
feat() : [MED-126-127] Prepare switch to ElasticSearch7 (conf + mapping)

### DIFF
--- a/deployment/mediacentre/conf.json.template
+++ b/deployment/mediacentre/conf.json.template
@@ -29,7 +29,10 @@
     "elasticsearch": true,
     "elasticsearchConfig" : {
         "server-uri": "${elasticServerURI}",
-        "index": "${elasticIndexName}"
+        "index": "${elasticIndexName}",
+        "elasticsearch-ssl": "${elasticSearchSsl}",
+        "username": "${elasticSearchUsername}",
+        "password": "${elasticSearchPassword}"
     }
   }
 }

--- a/migration/3.1.0/create_mappings.sh
+++ b/migration/3.1.0/create_mappings.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+curl -X PUT "http://192.168.240.31:9200/mediacentre" -H 'Content-Type: application/json' -d'
+{
+    "settings": {
+      "index": {
+        "blocks": {
+          "read_only_allow_delete": "false"
+        }
+      },
+      "analysis": {
+        "normalizer": {
+          "lower_normalizer": {
+            "type": "custom",
+            "char_filter": [],
+            "filter": ["lowercase", "asciifolding"]
+          }
+        }
+      }
+    },
+    "mappings": {
+        "resources": {
+            "properties": {
+                "title": {
+                    "type": "keyword",
+                    "normalizer": "lower_normalizer"
+                },
+                "authors": {
+                    "type": "keyword",
+                    "normalizer": "lower_normalizer"
+                },
+                "editors": {
+                    "type": "keyword",
+                    "normalizer": "lower_normalizer"
+                },
+                "image": {
+                    "type": "keyword",
+                    "index": false
+                },
+                "disciplines": {
+                    "type": "keyword",
+                    "normalizer": "lower_normalizer"
+                },
+                "levels": {
+                    "type": "keyword",
+                    "normalizer": "lower_normalizer"
+                },
+                "document_types": {
+                    "type": "keyword",
+                    "normalizer": "lower_normalizer"
+                },
+                "link": {
+                    "type": "keyword",
+                    "index": false
+                },
+                "source": {
+                    "type": "keyword"
+                },
+                "id": {
+                    "type": "keyword"
+                },
+                "date": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis",
+                    "index": false
+                },
+                "user": {
+                    "type": "keyword",
+                    "index": false
+                },
+                "structure": {
+                  "type": "keyword"
+                },
+                "description": {
+                  "type": "keyword",
+                  "normalizer": "lower_normalizer"
+                }
+            }
+        }
+    }
+}
+'

--- a/src/main/java/fr/openent/mediacentre/helper/TextBookHelper.java
+++ b/src/main/java/fr/openent/mediacentre/helper/TextBookHelper.java
@@ -69,7 +69,12 @@ public class TextBookHelper {
     public void initUserTextBooks(String state, UserInfos user, List<Source> sources, ResponseHandlerHelper answer) {
         sources = sources.stream().filter(source -> source instanceof GAR).collect(Collectors.toList());
         if (sources.isEmpty()) {
-            answer.answerFailure("[WebSocketController] Failed to retrieve GAR textbooks\"");
+            answer.answerFailure(HelperUtils.frameLoad(
+                    "textbooks_Result",
+                    state,
+                    "ko",
+                    new JsonObject().put("error", "[WebSocketController] Failed to retrieve GAR textbooks")
+            ).encode());
         } else {
             retrieveUserTextbooks(state, user, sources.get(0), answer);
         }


### PR DESCRIPTION
## Describe your changes
Mediacentre is a module using ElasticSearch 6 but we want to migrate to ES7 soon. In addition, some credentials will be added to ES for more security.
In consequence of these two points the mapping for the new ES had to change and credentials had to been added in configuration. The config is called and used within an ElasticSearchHelper in the Entcore. A modification has already been made and a PR created : https://github.com/opendigitaleducation/entcore/pull/288

## Checklist tests

## Issue ticket number and link
MED-126 (credentials) : https://entsupport.gdapublic.fr/browse/MED-126
MED-127 (mapping) : https://entsupport.gdapublic.fr/browse/MED-127

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)