### PR TITLE
fix(mediacentre-widget): [#FOR-214] avoid NPE for getUniversalis API point

### DIFF
--- a/src/main/java/fr/openent/mediacentre/controller/MediacentreController.java
+++ b/src/main/java/fr/openent/mediacentre/controller/MediacentreController.java
@@ -136,7 +136,7 @@ public class MediacentreController extends ControllerHelper {
                 JsonObject universalisJson = resources.stream()
                     .filter(JsonObject.class::isInstance)
                     .map(JsonObject.class::cast)
-                    .filter(resource -> resource.getString(LINK).contains(UNIVERSALIS_URL))
+                    .filter(resource -> resource.getString(LINK, "").contains(UNIVERSALIS_URL))
                     .findFirst()
                     .orElse(null);
                 GarResource universalis = universalisJson != null ? IModelHelper.toModel(universalisJson, GarResource.class) : null;


### PR DESCRIPTION
## Describe your changes
Fix NPE exception when calling getUniversalis API point. This was because a property was not always present and no default value was defined. Now it's fixed.

## Checklist tests

## Issue ticket number and link
MED-214 : https://jira.support-ent.fr/browse/MED-214

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)